### PR TITLE
Introducing new boolean option: useHeader.

### DIFF
--- a/Angular-csv.ts
+++ b/Angular-csv.ts
@@ -26,6 +26,7 @@ export class CsvConfigConsts {
     public static DEFAULT_SHOW_LABELS = false;
     public static DEFAULT_USE_BOM = true;
     public static DEFAULT_HEADER: any[] = [];
+    public static DEFAULT_USE_HEADER = false;
     public static DEFAULT_NO_DOWNLOAD = false;
     public static DEFAULT_NULL_TO_EMPTY_STRING = false;
 
@@ -41,6 +42,7 @@ export const ConfigDefaults: Options = {
     title: CsvConfigConsts.DEFAULT_TITLE,
     useBom: CsvConfigConsts.DEFAULT_USE_BOM,
     headers: CsvConfigConsts.DEFAULT_HEADER,
+    useHeader: CsvConfigConsts.DEFAULT_USE_HEADER,
     noDownload: CsvConfigConsts.DEFAULT_NO_DOWNLOAD,
     nullToEmptyString: CsvConfigConsts.DEFAULT_NULL_TO_EMPTY_STRING
 };
@@ -133,10 +135,15 @@ export class AngularCsv {
     getBody() {
         for (let i = 0; i < this.data.length; i++) {
             let row = "";
-            for (const index in this.data[i]) {
-                row += this.formatData(this.data[i][index]) + this._options.fieldSeparator;
+            if (this._options.useHeader && this._options.headers.length > 0) {
+               for (const index of this._options.headers) {
+                   row += this.formatData(this.data[i][index]) + this._options.fieldSeparator;
+               }
+            } else {
+               for (const index in this.data[i]) {
+                   row += this.formatData(this.data[i][index]) + this._options.fieldSeparator;
+               }
             }
-
             row = row.slice(0, -1);
             this.csv += row + CsvConfigConsts.EOL;
         }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ new AngularCsv(data, 'My Report');
 | **showLabels** | false      | If provided, would use this attribute to create a header row |
 | **showTitle** | false      |   |
 | **useBom** | true      | If true, adds a BOM character at the start of the CSV |
+| **useHeader** | false      | If true, only fields listed in header will be exported in CSV |
 | **noDownload** | false      | If true, disables automatic download and returns only formatted CSV |
 | **nullToEmptyString** | false      | If true, all null values will be changed to empty strings |
 
@@ -80,6 +81,7 @@ new AngularCsv(data, 'My Report');
     useBom: true,
     noDownload: true,
     headers: ["First Name", "Last Name", "ID"],
+    useHeader: false,
     nullToEmptyString: true,
   };
 


### PR DESCRIPTION
If true, only fields listed in header will be exported in CSV.
It is very helpfully if only selected fields need to be exported.